### PR TITLE
Update deprecated upload artifacts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,12 +80,12 @@ runs:
       shell: bash
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: all
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       with:
         version: latest
 
@@ -114,7 +114,7 @@ runs:
 
     - name: Login to DockerHub
       if: success()
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
@@ -196,7 +196,7 @@ runs:
         path: '*amd64.tar'
 
     - name: Upload docker image for release
-      uses: svenstaro/upload-release-action@v2
+      uses: svenstaro/upload-release-action@v3
       if: startsWith(github.ref, 'refs/tags') && success()
       with:
         repo_token: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -149,7 +149,7 @@ runs:
       shell: bash
 
     - name: Upload artifact arm64-v8
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: ${{ inputs.image-prefix }}${{ inputs.image-name }}-docker-image-arm64-v8
@@ -169,7 +169,7 @@ runs:
       shell: bash
 
     - name: Upload artifact arm-v7
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: ${{ inputs.image-prefix }}${{ inputs.image-name }}-docker-image-arm-v7
@@ -189,7 +189,7 @@ runs:
       shell: bash
 
     - name: Upload artifact amd64
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: ${{ inputs.image-prefix }}${{ inputs.image-name }}-docker-image-amd64


### PR DESCRIPTION
This is failing new builds:

```bash
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```