### PR TITLE
action.yml: roll back non-existent version update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -196,7 +196,7 @@ runs:
         path: '*amd64.tar'
 
     - name: Upload docker image for release
-      uses: svenstaro/upload-release-action@v3
+      uses: svenstaro/upload-release-action@v2
       if: startsWith(github.ref, 'refs/tags') && success()
       with:
         repo_token: ${{ inputs.github-token }}


### PR DESCRIPTION
#4 did a bulk replacement of `v2` -> `v3`, but missed that one of the actions was not from `docker`, and does not even have a `v3`.

Thanks @RaulTrombin for pointing out that this was breaking stuff, before we turned it into a release...